### PR TITLE
Add i18nPro context implementation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,35 @@ The updated locale, or an empty string if the locale was not updated.
 
 The HOC returns a new component that renders the `WrappedComponent` with the additional `i18nPro` props. The returned component accepts all the props of the `WrappedComponent`, except for the props provided by the `useI18nPro` hook.
 
+### I18nProProvider
+
+`I18nProProvider` is a context provider component that supplies `i18nPro` functionality to its child components. It uses the `useI18nPro` hook to provide internationalization (i18n) capabilities to the components within its context.
+
+#### Parameters
+
+- `children`: The child components that will have access to the `i18nPro` context.
+
+#### Return Value
+
+The `I18nProProvider` returns a context provider that wraps its children with the `i18nPro` context. The wrapped children will have access to the `i18nPro` context values, such as `locale`, `switchLoadLanguage`, `t`, and `updateExisitngLocale`.
+
+### useI18nProContext
+
+`useI18nProContext` is a custom hook that provides access to the `i18nPro` context. It must be used within a component that is a descendant of the `i18nProProvider`.
+
+#### Return Value
+
+The hook returns the `i18nPro` context values, including:
+
+- `locale`: The current locale.
+- `switchLoadLanguage`: A function to switch the current language.
+- `t`: A function to translate text.
+- `updateExisitngLocale`: A function to update the existing locale.
+
+#### Error Handling
+
+If `useI18nProContext` is used outside of an `i18nProProvider`, it will throw an error with the message: "useI18nProContext must be used within an I18nProProvider".
+
 ## License
 
 This project is licensed under the [MIT License](./LICENSE).

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type { JestConfigWithTsJest } from 'ts-jest'
 import { defaults as tsjPreset } from 'ts-jest/presets'
 
 const jestConfig: JestConfigWithTsJest = {
+  cache: false,
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverage: true,
   coverageProvider: 'v8',

--- a/src/context/i18nProContext.tsx
+++ b/src/context/i18nProContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, PropsWithChildren, useContext } from 'react'
+import { useI18nPro } from '../hook/useI18nPro'
+import { I18nProContextType } from '../types/context'
+
+const i18nProContext = createContext<I18nProContextType | null>(null)
+
+export const I18nProProvider = ({ children }: PropsWithChildren) => {
+  const { locale, switchLoadLanguage, t, updateExisitngLocale } = useI18nPro()
+  console.log(locale)
+  return (
+    <i18nProContext.Provider
+      value={{
+        locale,
+        switchLoadLanguage,
+        t,
+        updateExisitngLocale
+      }}
+    >
+      {children}
+    </i18nProContext.Provider>
+  )
+}
+
+export const useI18nProContext = () => {
+  const context = useContext(i18nProContext)
+  if (!context) {
+    console.error('useI18nProContext must be used within an I18nProProvider')
+    throw new Error('useI18nProContext must be used within an I18nProProvider')
+  }
+  return context
+}

--- a/src/test/i18nProcontext.spec.tsx
+++ b/src/test/i18nProcontext.spec.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { I18nProProvider, useI18nProContext } from '../context/i18nProContext'
+import { i18nPro } from '@marchintosh94/i18n-pro'
+
+describe('I18nProContext', () => {
+  i18nPro.defaultLocale = 'fr'
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render children and provide context values', () => {
+    render(
+      <I18nProProvider>
+        <div>Test Child</div>
+      </I18nProProvider>
+    )
+
+    expect(screen.getByText('Test Child')).toBeInTheDocument()
+  })
+
+  it('should provide correct context values and update locale on load', () => {
+    const TestComponent = () => {
+      const { locale, switchLoadLanguage, t } = useI18nProContext()
+      useEffect(() => {
+        switchLoadLanguage('en-us', {
+          change_language: 'change language'
+        })
+      }, [])
+      return (
+        <div>
+          <span>{locale}</span>
+          <button
+            onClick={() =>
+              switchLoadLanguage('es', {
+                change_language: 'cambiar el idioma'
+              })
+            }
+          >
+            {t('change_language')}
+          </button>
+        </div>
+      )
+    }
+
+    const { container } = render(
+      <I18nProProvider>
+        <TestComponent />
+      </I18nProProvider>
+    )
+
+    expect(screen.getByText('fr')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toHaveTextContent('change_language')
+    waitFor(() => {
+      expect(screen.getByText('en-us')).toBeInTheDocument()
+      expect(screen.getByRole('button')).toHaveTextContent('change language')
+      console.log(container.innerHTML)
+    })
+  })
+  it('should provide update locale when new laguage has been loaded', () => {
+    const TestComponent = () => {
+      const { locale, switchLoadLanguage, t } = useI18nProContext()
+
+      return (
+        <div>
+          <span>{locale}</span>
+          <button
+            onClick={() =>
+              switchLoadLanguage('es', {
+                change_language: 'cambiar el idioma'
+              })
+            }
+          >
+            {t('change_language')}
+          </button>
+        </div>
+      )
+    }
+
+    const { container } = render(
+      <I18nProProvider>
+        <TestComponent />
+      </I18nProProvider>
+    )
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button'))
+    })
+    waitFor(() => {
+      expect(screen.getByText('es')).toBeInTheDocument()
+      expect(screen.getByRole('button')).toHaveTextContent('cambiar el idioma')
+    })
+  })
+
+  it('should throw error when useI18nProContext is used outside of I18nProProvider', () => {
+    const TestComponent = () => {
+      try {
+        useI18nProContext()
+      } catch (e) {
+        return <div>{(e as Error).message}</div>
+      }
+      return <></>
+    }
+
+    render(<TestComponent />)
+
+    expect(
+      screen.getByText(
+        'useI18nProContext must be used within an I18nProProvider'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,0 +1,3 @@
+import { useI18nPro } from '../hook/useI18nPro'
+
+export type I18nProContextType = ReturnType<typeof useI18nPro>


### PR DESCRIPTION
- Updated to include documentation for the new i18nPro context, detailing how to use the I18nProProvider and useI18nProContext hooks.
- Added a new context implementation for i18nPro. This file defines the I18nProProvider component and the useI18nProContext hook.
- Added new type definitions for the i18nPro context. This includes the I18nProContextType which is derived from the return type of the useI18nPro hook.
- Added new test cases for the i18nPro context. These tests verify the functionality of the I18nProProvider and useI18nProContext hooks, ensuring they provide the correct context values and handle language switching correctly.